### PR TITLE
Fix dockerfile to always include dev deps

### DIFF
--- a/server/dockerfile
+++ b/server/dockerfile
@@ -5,7 +5,7 @@ FROM node:20
 WORKDIR /app
 COPY . .
 
-RUN npm install
+RUN npm install --include=dev
 RUN npm run tsoa-build
 
 CMD ["npx", "ts-node", "src/index.ts"]


### PR DESCRIPTION
## Summary
- install dev packages during container build so tsoa and other tools exist

## Testing
- `npm install --include=dev` *(fails: 403 Forbidden due to network restrictions)*
- `npm run tslint` *(fails: tslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fdb73c188324bb58371515975ee6